### PR TITLE
General cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,6 @@ ARG ROOT_HINTS
 ARG ICANN_CERT
 
 COPY --from=openssl /opt/openssl /opt/openssl
-COPY ./data/etc/ /opt/unbound/etc/
-COPY ./data/unbound.bootstrap /opt/unbound/unbound.bootstrap
 
 # Ignore DL3020, using ADD to grab remote file. Cannot do with COPY
 # hadolint ignore=DL3020
@@ -122,7 +120,6 @@ RUN <<EOF
     mv /opt/unbound/etc/unbound/unbound.conf /opt/unbound/etc/unbound/unbound.conf.example
     rm -rf /opt/unbound/sbin/unbound-host
     find /opt/unbound/sbin -type f -exec strip '{}' \; -exec upx --best --lzma -q '{}' \;
-    chmod +x /opt/unbound/unbound.bootstrap
     apk del build-deps ${CORE_BUILD_DEPS}
 EOF
 
@@ -176,12 +173,16 @@ SHELL ["/bin/sh", "-cexo", "pipefail"]
 
 COPY --from=base /bin/busybox /lib/ld-musl*.so.1 /lib/
 COPY --from=base /etc/ssl/certs/ /etc/ssl/certs/
+
 COPY --from=ldns /opt/ldns/bin/drill /bin/drill
+
 COPY --from=unbound /opt/unbound/sbin/ /sbin/
 COPY --from=unbound /opt/unbound/etc/ /var/chroot/unbound/etc/
 COPY --from=unbound /opt/unbound/var/ /var/chroot/unbound/var/
 COPY --from=unbound /etc/passwd /etc/group /etc/
-COPY --from=unbound /opt/unbound/unbound.bootstrap /unbound
+
+COPY ./data/etc/ /var/chroot/unbound/etc/
+COPY --chmod=744 ./data/unbound.bootstrap /unbound
 
 RUN ["/lib/busybox", "ln", "-s", "/lib/busybox", "/bin/sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+# DL3018: We're specifying pkgs via ARGs + want latest security updates if possible. 
+#         Will pin if there are any future issues.
+# SC2086: Not needed in the majority of cases here (like apk calls that expect a list of pkgs, not a string).
+# DL3020: A bug maybe? All these appear for ARGs with URLs in ADD statements.
+# DL3003: Not splitting up RUNs just to cd.
+# hadolint global ignore=DL3018,SC2086,DL3020,DL3003
+
 ARG ALPINE_VERSION=latest
 
 FROM alpine:${ALPINE_VERSION} AS base
@@ -5,11 +12,8 @@ ARG CORE_BUILD_DEPS
 ENV CORE_BUILD_DEPS=${CORE_BUILD_DEPS}
 
 WORKDIR /tmp/src
-SHELL ["/bin/sh", "-cexo", "pipefail"]
+SHELL ["/bin/ash", "-cexo", "pipefail"]
 
-# Ignore DL3018, we're specifying pkgs via env
-# Ignore SC2086, need to leave out double quotes to bring in deps via env
-# hadolint ignore=DL3018,SC2086
 RUN <<EOF
     apk --no-cache upgrade
     apk add --no-cache ${CORE_BUILD_DEPS}
@@ -25,16 +29,9 @@ ARG OPENSSL_VERSION
 ARG OPENSSL_SOURCE_FILE=openssl-${OPENSSL_VERSION}.tar.gz
 ARG OPENSSL_DOWNLOAD_URL=${OPENSSL_SOURCE}/${OPENSSL_SOURCE_FILE}
 
-# Ignore DL3020, using ADD to grab remote file. Cannot do with COPY
-# hadolint ignore=DL3020
 ADD --checksum=sha256:${OPENSSL_SHA256} ${OPENSSL_DOWNLOAD_URL} openssl.tar.gz
-# hadolint ignore=DL3020
 ADD ${OPENSSL_DOWNLOAD_URL}.asc openssl.tar.gz.asc
 
-# Ignore DL3018, we're specifying pkgs via env
-# Ignore SC2086, need to leave out double quotes to bring in deps via env
-# Ignore DL3003, only need to cd for this RUN
-# hadolint ignore=DL3003,DL3018,SC2086
 RUN <<EOF
     GNUPGHOME="$(mktemp -d)"
     export GNUPGHOME
@@ -71,19 +68,12 @@ ARG ICANN_CERT
 
 COPY --from=openssl /opt/openssl /opt/openssl
 
-# Ignore DL3020, using ADD to grab remote file. Cannot do with COPY
-# hadolint ignore=DL3020
 ADD ${ROOT_HINTS} /opt/unbound/var/unbound/root.hints
-# hadolint ignore=DL3020
 ADD ${ICANN_CERT} /opt/unbound/var/unbound/icannbundle.pem
-# hadolint ignore=DL3020
 ADD --checksum=sha256:${UNBOUND_SHA256} ${UNBOUND_DOWNLOAD_URL} unbound.tar.gz
 
-# Ignore DL3018, we're specifying pkgs via env
-# Ignore SC2086, need to leave out double quotes to bring in deps via env
-# Ignore DL3003, only need to cd for this RUN
 # Ignore SC2034, Needed to static-compile unbound/ldns, per https://github.com/NLnetLabs/unbound/issues/91#issuecomment-1707544943
-# hadolint ignore=DL3018,SC2086,DL3003,SC2034
+# hadolint ignore=SC2034
 RUN <<EOF
     mkdir ./unbound-src
     apk add --no-cache --virtual build-deps ${UNBOUND_BUILD_DEPS}
@@ -93,7 +83,6 @@ RUN <<EOF
     addgroup -S _unbound
     adduser -S -s /dev/null -h /etc/unbound -G _unbound _unbound
     
-#   Needed to static-compile unbound, per https://github.com/NLnetLabs/unbound/issues/91#issuecomment-1707544943
     sed -e 's/@LDFLAGS@/@LDFLAGS@ -all-static/' -i Makefile.in
     LIBS="-lpthread -lm"
     LDFLAGS="-Wl,-static -static -static-libgcc"
@@ -134,15 +123,11 @@ ARG LDNS_DOWNLOAD_URL=${LDNS_SOURCE}/${LDNS_SOURCE_FILE}
 
 COPY --from=openssl /opt/openssl /opt/openssl
 
-# Ignore DL3020, using ADD to grab remote file. Cannot do with COPY
-# hadolint ignore=DL3020
 ADD --checksum=sha256:${LDNS_SHA256} ${LDNS_DOWNLOAD_URL} ldns.tar.gz
 
-# Ignore DL3018, we're specifying pkgs via env
-# Ignore SC2086, need to leave out double quotes to bring in deps via env
-# Ignore DL3003, only need to cd for this RUN
+
 # Ignore SC2034, Needed to static-compile unbound/ldns, per https://github.com/NLnetLabs/unbound/issues/91#issuecomment-1707544943
-# hadolint ignore=DL3018,SC2086,DL3003,SC2034
+# hadolint ignore=SC2034
 RUN <<EOF
     mkdir ./ldns-src
     apk add --no-cache --virtual build-deps ${LDNS_BUILD_DEPS}
@@ -169,7 +154,8 @@ EOF
 
 FROM scratch AS final
 WORKDIR /
-SHELL ["/bin/sh", "-cexo", "pipefail"]
+SHELL ["/bin/ash", "-cexo", "pipefail"]
+ENV PATH="/bin:/sbin"
 
 COPY --from=base /bin/busybox /lib/ld-musl*.so.1 /lib/
 COPY --from=base /etc/ssl/certs/ /etc/ssl/certs/
@@ -184,24 +170,20 @@ COPY --from=unbound /etc/passwd /etc/group /etc/
 COPY ./data/etc/ /var/chroot/unbound/etc/
 COPY --chmod=744 ./data/unbound.bootstrap /unbound
 
-RUN ["/lib/busybox", "ln", "-s", "/lib/busybox", "/bin/sh"]
+RUN ["/lib/busybox", "ln", "-s", "/lib/busybox", "/bin/ash"]
 
-ENV PATH="/bin:/sbin"
-ENV SH_CMDS="ln sed grep chmod chown mkdir cp awk uniq bc rm find nproc"
-
-# Ignore DL4006, I want /bin/sh, dammit!
 # Ignore SC2005:
-#       We're using echo/grep below because technically unbound-anchor returns code 1
-#       if creating root.key for the first time, causing the build to fail.
-#       Just make sure the anchor is actually OK first.
+#     We're using echo/grep below because technically unbound-anchor returns code 1
+#     if creating root.key for the first time, causing the build to fail.
+#     Just make sure the anchor is actually OK first.
 #
-# hadolint ignore=DL4006,SC2005
+# hadolint ignore=SC2005
 RUN <<EOF
+    SH_CMDS="ln sed grep chmod chown mkdir cp awk uniq bc rm find nproc"
+    
     for link in ${SH_CMDS}; do
-        /lib/busybox ln -s /lib/busybox /bin/"$link"
+        /lib/busybox ln -s /lib/busybox /bin/${link}
     done
-
-    unset SH_CMDS
 
     ln -s /var/chroot/unbound/var/unbound/ /var/unbound
     ln -s /var/chroot/unbound/etc/unbound/ /etc/unbound

--- a/Dockerfile
+++ b/Dockerfile
@@ -186,7 +186,7 @@ COPY --from=unbound /opt/unbound/unbound.bootstrap /unbound
 RUN ["/lib/busybox", "ln", "-s", "/lib/busybox", "/bin/sh"]
 
 ENV PATH="/bin:/sbin"
-ENV SH_CMDS="ln sed grep chmod chown mkdir cp awk uniq bc rm find"
+ENV SH_CMDS="ln sed grep chmod chown mkdir cp awk uniq bc rm find nproc"
 
 # Ignore DL4006, I want /bin/sh, dammit!
 # Ignore SC2005:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ SHELL ["/bin/sh", "-cexo", "pipefail"]
 # Ignore SC2086, need to leave out double quotes to bring in deps via env
 # hadolint ignore=DL3018,SC2086
 RUN <<EOF
-    apk update
+    apk --no-cache upgrade
     apk add --no-cache ${CORE_BUILD_DEPS}
 EOF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,6 @@ RUN <<EOF
         --disable-rpath
     make -j install
     mv /opt/unbound/etc/unbound/unbound.conf /opt/unbound/etc/unbound/unbound.conf.example
-    rm -rf /opt/unbound/sbin/unbound-host
     find /opt/unbound/sbin -type f -exec strip '{}' \; -exec upx --best --lzma -q '{}' \;
     apk del build-deps ${CORE_BUILD_DEPS}
 EOF

--- a/data/unbound.bootstrap
+++ b/data/unbound.bootstrap
@@ -7,23 +7,23 @@ if [ ! -f /etc/unbound/unbound.conf ]; then
     totalMemory=$((1024 * $( awk '/^MemTotal/ { print $2 }' /proc/meminfo ) ))
 
     # Limit available memory for unbound to 1/4 of total system available
-    availableMemory=$totalMemory
+    availableMemory=${totalMemory}
 
     # Use roughly twice as much rrset cache memory as msg cache memory
-    rr_cache_size=$(($availableMemory / 3))
-    msg_cache_size=$(($rr_cache_size / 2))
+    rr_cache_size=$((${availableMemory} / 3))
+    msg_cache_size=$((${rr_cache_size} / 2))
 
     # Use # of CPUs/threads to calculate threads and slabs
     nproc=$(nproc)
-    if [ "$nproc" -gt 1 ]; then
-        threads=$nproc
+    if [ "${nproc}" -gt 1 ]; then
+        threads=${nproc}
         
         # Calculate base 2 log of the number of processors
         nproc_log=$(printf '%.0f\n' $(echo "l(${nproc}) / l(2)" | bc -l))
 
         # Set *-slabs to a power of 2 close to the num-threads value.
         # This reduces lock contention.
-        slabs=$(( 2 ** nproc_log ))
+        slabs=$(( 2 ** ${nproc_log} ))
     else
         threads=1
         slabs=2
@@ -36,7 +36,7 @@ if [ ! -f /etc/unbound/unbound.conf ]; then
         -e "s/@SLABS@/${slabs}/" \
         /etc/unbound/unbound.conf.template > /etc/unbound/unbound.conf
     cp /etc/unbound/unbound.conf /etc/unbound/unbound.conf.default
-    chmod 0444 /etc/unbound/unbound.conf.default
+    chmod 444 /etc/unbound/unbound.conf.default
 fi
 
 rm /etc/unbound/unbound.conf.template
@@ -51,7 +51,5 @@ ln -s /sbin/unbound /unbound
 find /bin -type l -delete
 
 /lib/busybox rm -rf /lib
-
-unset PATH
 
 exec /sbin/unbound "$@"

--- a/data/unbound.bootstrap
+++ b/data/unbound.bootstrap
@@ -13,8 +13,8 @@ if [ ! -f /etc/unbound/unbound.conf ]; then
     rr_cache_size=$(($availableMemory / 3))
     msg_cache_size=$(($rr_cache_size / 2))
 
-    # Use # of physical CPUs to calculate threads and slabs
-    nproc=$(awk '/^cpu cores/ { print $4 }' /proc/cpuinfo | uniq)
+    # Use # of CPUs/threads to calculate threads and slabs
+    nproc=$(nproc)
     if [ "$nproc" -gt 1 ]; then
         threads=$nproc
         

--- a/data/unbound.bootstrap
+++ b/data/unbound.bootstrap
@@ -7,7 +7,7 @@ if [ ! -f /etc/unbound/unbound.conf ]; then
     totalMemory=$((1024 * $( awk '/^MemTotal/ { print $2 }' /proc/meminfo ) ))
 
     # Limit available memory for unbound to 1/4 of total system available
-    availableMemory=$(($totalMemory / 4))
+    availableMemory=$totalMemory
 
     # Use roughly twice as much rrset cache memory as msg cache memory
     rr_cache_size=$(($availableMemory / 3))

--- a/data/unbound.bootstrap
+++ b/data/unbound.bootstrap
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/ash
 
 # Performance tuning before final cleanup and run
 # See: https://unbound.docs.nlnetlabs.nl/en/latest/topics/core/performance.html


### PR DESCRIPTION
- Re-enabled `nproc` to calculate container CPUs vs `/etc/cpuinfo` due to it always listing full host CPU set regardless of Docker limitations. Will leave up to the user to restrict CPU allocated to the container.
- Removed modifier for `availableMemory` in bootstrap script. Similar to above, will leave up to the user for mem usage.
- Added unbound-host back into the image.
- General file cleanup